### PR TITLE
Add github workflow for deploying extension

### DIFF
--- a/.github/workflows/vsce-publish.yml
+++ b/.github/workflows/vsce-publish.yml
@@ -1,0 +1,27 @@
+name: VSCE Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v0
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OPENVSX_PERSONAL_ACCESS_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.VSCODE_PERSONAL_ACCESS_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          packagePath: ""

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 out/
 package-lock.json
 *nls.*.json
+*.qbs.user

--- a/vscode-qbs.qbs
+++ b/vscode-qbs.qbs
@@ -23,4 +23,9 @@ Product {
         prefix: "src/"
         files: "**/*"
     }
+    Group {
+        name: "ci"
+        prefix: ".github/"
+        files: "**/*"
+    }
 }


### PR DESCRIPTION
Deploys to the Visual studio marketplace and open registry whenever a new release is created. 
I have taken the example from here: https://github.com/HaaLeo/publish-vscode-extension
The pipeline uses `npm install` instead of `npm ci` because the package-lock.json is missing in the repository.