### PR TITLE
Fix debugger on macOS

### DIFF
--- a/src/commands/qbsrunproductcommand.ts
+++ b/src/commands/qbsrunproductcommand.ts
@@ -25,7 +25,7 @@ export async function onRunProduct(session: QbsSession) {
 
     const escaped = QbsUtils.escapeShell(dbg.program());
     const program = dbg.program();
-    const env = dbg.environment().data();
+    const env = dbg.environmentData().data();
     const terminal = vscode.window.createTerminal({
         name: 'QBS Run',
         env,

--- a/src/datatypes/qbsdebuggerdata.ts
+++ b/src/datatypes/qbsdebuggerdata.ts
@@ -4,6 +4,8 @@ import {QbsDebuggerKey} from './qbskeys';
 import {QbsRunEnvironmentData} from './qbsrunenvironmentdata';
 
 export class QbsDebuggerData {
+    private _envData: QbsRunEnvironmentData = new QbsRunEnvironmentData({});
+
     constructor(private readonly _data: any) {}
 
     setName(name: string) {
@@ -42,12 +44,23 @@ export class QbsDebuggerData {
         return this._data[QbsDebuggerKey.Cwd] || '';
     }
 
-    setEnvironment(env: QbsRunEnvironmentData) {
-        this._data[QbsDebuggerKey.Env] = env.data();
-    };
+    environment(): object {
+        return this._data[QbsDebuggerKey.Environment] || {};
+    }
 
-    environment(): QbsRunEnvironmentData {
-        return new QbsRunEnvironmentData(this._data[QbsDebuggerKey.Env] || {});
+    setEnvironmentData(env: QbsRunEnvironmentData) {
+        this._envData = env;
+        const environment = Object.entries(env.data()).map(function([k, v]) {
+            return {
+                name: k,
+                value: v
+            };
+        });
+        this._data[QbsDebuggerKey.Environment] = environment;
+    }
+
+    environmentData(): QbsRunEnvironmentData {
+        return this._envData;
     }
 
     setExternalConsole(console: boolean) {

--- a/src/datatypes/qbskeys.ts
+++ b/src/datatypes/qbskeys.ts
@@ -104,7 +104,7 @@ export enum QbsQbsKey {
 export enum QbsDebuggerKey {
     Configutations = 'configurations',
     Cwd = 'cwd',
-    Env = 'env',
+    Environment = 'environment',
     ExternalConsole = 'console',
     IsAutomatic = 'is-automatic',
     MiDebuggerPath = 'miDebuggerPath',


### PR DESCRIPTION
We need to use lldb-mi (machine interface) adapter instead
of real lldb. lldb-mi is sipped with cpptools extension and thus
we should use it if there is no system one (which is a rare case).

Also, use "environment" key in dbg dict instead of "env" since
lldb doesn't support "env".