### PR TITLE
Add support for resolving VS Code variables and relative paths in Qbs plugin paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -589,6 +589,7 @@
         "vscode-cpptools": "^6.1.0",
         "vscode-languageclient": "^9.0.1",
         "vscode-nls": "^5.0.0",
+        "vscode-variables": "^1.0.1",
         "which": "~2.0.2"
     },
     "overrides": {

--- a/src/qbsbuildsystem.ts
+++ b/src/qbsbuildsystem.ts
@@ -2,8 +2,9 @@ import { performance } from 'perf_hooks';
 import * as fs from 'fs';
 import * as nls from 'vscode-nls';
 import * as vscode from 'vscode';
+import * as path from 'path';
 
-import { msToTime, trySaveAll, fixFsPathSeparators } from './qbsutils';
+import { msToTime, trySaveAll, fixFsPathSeparators, resolveVariables } from './qbsutils';
 import { QbsBuildConfigurationManager } from './qbsbuildconfigurationmanager';
 import { QbsBuildVariant } from './datatypes/qbsbuildvariant';
 import { QbsCommandKey } from './datatypes/qbscommandkey';
@@ -981,7 +982,9 @@ export class QbsBuildSystem implements vscode.Disposable {
         fsPath = QbsSettings.substituteProjectName(fsPath, projectName);
         fsPath = QbsSettings.substituteBuildProfileName(fsPath, profileName);
         fsPath = QbsSettings.substituteBuildConfigurationName(fsPath, configurationName);
-        return fixFsPathSeparators(fsPath);
+        fsPath = resolveVariables(fsPath);
+        fsPath = fixFsPathSeparators(fsPath)
+        return path.resolve(sourceRoot, fsPath);
     }
 
     private static getBuildRootDirectoryPathFromSettings(): string | undefined {

--- a/src/qbssession.ts
+++ b/src/qbssession.ts
@@ -10,6 +10,7 @@ import { QbsProtocolEngine } from './protocol/qbsprotocolengine';
 import { QbsProtocolEngineState } from './protocol/qbsprotocolengine';
 import { QbsProtocolProjectData } from './protocol/qbsprotocolprojectdata';
 import { QbsSettings } from './qbssettings';
+import { resolveVariables } from './qbsutils';
 
 // Protocol request.
 import { QbsProtocolRequest } from './protocol/qbsprotocolrequest';
@@ -117,7 +118,7 @@ export class QbsSession implements vscode.Disposable {
 
     private registerCommandsHandlers(context: vscode.ExtensionContext): void {
         context.subscriptions.push(vscode.commands.registerCommand(QbsCommandKey.StartSession, async () => {
-            await this.startSession(QbsSettings.getQbsPath());
+            await this.startSession(resolveVariables(QbsSettings.getQbsPath()));
         }));
         context.subscriptions.push(vscode.commands.registerCommand(QbsCommandKey.StopSession, async () => {
             await this.stopSession();

--- a/src/qbsutils.ts
+++ b/src/qbsutils.ts
@@ -6,6 +6,8 @@ import * as vscode from 'vscode';
 
 const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
+const vscodeVariables = require('vscode-variables');
+
 export function getHash(input: BinaryLike) {
     const hash = createHash('sha1');
     hash.update(input);
@@ -23,6 +25,14 @@ export function escapeShell(shell: string): string {
         return `"${shell}"`;
     }
     return shell;
+}
+
+export function resolveVariables(s: string, recursive: boolean = true): string {
+    return vscodeVariables(s, recursive);
+}
+
+export function workspaceFolder(): string {
+    return vscodeVariables('${workspaceFolder}', true);
 }
 
 export function trimLine(line: string): string { return line.replace(/[\n\r]/g, ''); }


### PR DESCRIPTION
Build directory and settings directory may use relative paths and standard variables like ${userHome}. Qbs path must be absolute but may use standard variables.

Uses module vscode-variables from https://github.com/DominicVonk/vscode-variables